### PR TITLE
Fix new password field error check

### DIFF
--- a/src/js/forms/fields/new-password-field.jsx
+++ b/src/js/forms/fields/new-password-field.jsx
@@ -70,7 +70,8 @@ export default class NewPasswordField extends Field {
   get errorMessageNode() {
     const { errorMessage: em, patterns } = this.props;
     const { error, value } = this.state;
-    if (!error && !errorMessage || !patterns) return false;
+    if (!error) return false;
+    if (!em && !patterns) return false;
     const errorMessage = !patterns ? [em] : [
       em, React.createElement('ul', {},
         ...Object.entries(patterns)


### PR DESCRIPTION
## Summary
- fix variable reference when checking for password error messages

## Testing
- `node tests/resolve-refs-with-rules.js` *(fails: Cannot find package 'dbl-utils')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68671191a3d4832685ecfbb09db16821